### PR TITLE
Wireless properties, MTU

### DIFF
--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -99,7 +99,7 @@ Disjointness:
 : How disjoint a path is from another path.
 
 Path MTU:
-: The end-to-end maximum transmission unit in one packet.
+: The maximum size, in octets, of an IP packet that can be transmitted without fragmentation on a path segment or path.
 
 Transport Protocols available:
 : Whether a specific transport protocol can be used to establish a connection over this path. An endpoint may know this because it has cached whether it could successfully establish, e.g., a QUIC connection, or an MPTCP subflow.
@@ -122,9 +122,11 @@ See {{ANRW18-Metrics}} for a discussion of how to measure some dynamic path prop
 These properties may be symmetric or asymmetric. For example, an asymmetric property may be different in the upstream direction and in the downstream direction from the point of view of a particular host.
 
 
+Maximum Data Rate (Transmit/Receive):
+: The theoretical maximum data rate, in bits per second, that can be achieved on a link, path segment, or path, for receiving or transmitting traffic.
 
-Available bandwidth:
-: Maximum number of bytes per second that can be sent or received over this path. This depends on the available bandwidth at the bottleneck, and on crosstraffic.
+Current Data Rate (Transmit/Receive):
+: The data rate, in bits per second, at which a link is currently receiving or transmitting traffic.
 
 Round Trip Time:
 : Time from sending a packet to receiving a response from the remote endpoint.
@@ -137,15 +139,6 @@ Packet Loss:
 
 Congestion:
 : Whether there is any indication of congestion on the path.
-
-Wireless Signal strength:
-: Power level of the wireless signal being received. Lower signal strength, relative to the same noise floor, is correlated with higher bit error rates and lower modulation rates.
-
-Wireless Modulation Rate:
-: Modulation bitrate of the wireless signal. The modulation rate determines how many bytes are transmitted within a symbol on the wireless channel. A high modulation rate leads to a higher possible bitrate, given sufficient signal strength.
-
-Wireless Channel utilization:
-: Percentage of time during which there is a transmission on the wireless medium. A high channel utilization indicates a congested wireless network.
 
 
 # Security Considerations

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -31,6 +31,8 @@ informative:
 
     RFC7556:
 
+    RFC8175:
+
     ANRW18-Metrics: DOI.10.1145/3232755.3232764
 
 --- abstract
@@ -113,6 +115,7 @@ Protocol Features available:
 Dynamic Path Properties are expected to change on the timescale of milliseconds.
 They usually relate to the state of the path, such as the current end-to-end latency.
 Some of these properties may depend only on the first hop or on the access network, some may depend on the entire path.
+Properties related to a single layer 2 domain are abstracted from the used physical and link layer technology, similar to {{RFC8175}}.
 
 Typically, Dynamic Properties can only be approximated and sampled, and might be made available in an aggregated form, such as averages or minimums.
 Dynamic Path Properties can be measured by the endpoint itself or somethere in the network.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -111,7 +111,7 @@ Protocol Features available:
 # Dynamic Properties
 
 Dynamic Path Properties are expected to change on the timescale of milliseconds.
-They usually relate to the state of the path, such as the currently available end-to-end bandwidth.
+They usually relate to the state of the path, such as the current end-to-end latency.
 Some of these properties may depend only on the first hop or on the access network, some may depend on the entire path.
 
 Typically, Dynamic Properties can only be approximated and sampled, and might be made available in an aggregated form, such as averages or minimums.


### PR DESCRIPTION
This (really short) Pull Request substitutes the Wireless properties with the more abstract data rates based on RFC 8175.
Also, I substituted "available bandwidth" (capacity) with "maximum data rate" in the process, because it's actually the same thing, just available bandwidth (capacty) is supposed to apply to the entire path instead of just one link.
Now this is the theoretical maximum of all links on the path, which might be different from the actually achievable throughput on this path. But I'm not sure we will be able to specify the actually achievable throughput on a path with the definition of path on a per-packet basis and with flows... maybe the flow can have a maximum throughput later? But that's future work.

In this PR, I'm not sure if we need to reference RFC 8175? It inspires our definition, but then again, it's not like they provide an entirely novel thing... And DLEP would be a way to gather these properties, but how to gather properties is out of scope for our draft.

Any opinions?