### PR TITLE
Redefine domain, backbone, and dynamic properties

### DIFF
--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -29,8 +29,6 @@ informative:
 
     I-D.irtf-panrg-questions:
 
-    RFC7556:
-
     RFC8175:
 
     ANRW18-Metrics: DOI.10.1145/3232755.3232764
@@ -66,63 +64,62 @@ in Path-Aware Networking {{I-D.irtf-panrg-questions}}, which is a product of the
 
 # Domain Properties
 
-Domain path properties usually relate to the access network within the first hop or the first few hops.
-Endpoints can influence domain properties for example by switching from a WiFi to a cellular interface, changing their data plan to increase throughput, or moving closer to a wireless access point which increases the signal strength.
+Domain path properties relate to path elements within the same Autonomous System (AS), thus, in the same administrative domain as an endpoint considering them.
 
-A large amount of information about domain properties exists.
-Properties related to configuration can be queried using provisioning domains (PvDs).
-A PvD is a consistent set of network configuration information as defined in {{RFC7556}}, e.g., relating to a local network interface.
-This may include source IP address prefixes, IP addresses of DNS servers, name of an HTTP proxy server, DNS suffixes associated with the network, or default gateway IP address.
-As one PvD is not restricted to one local network interface, a PvD may also apply to multiple paths.
+Due to the potential physical proximity and pre-existing trust or contractual relationships between endpoints and path elements within the same administrative domain, domain properties may be more easily available to the endpoint than the properties of path elements outside of its administrative domain.
 
-Access Technology present on the path:
-: The lower layer technology on the first hop, for example, WiFi, Wired Ethernet, or Cellular. This can also be more detailed, e.g., further specifying the Cellular as 2G, 3G, 4G, or 5G technology, or the WiFi as 802.11a, b, g, n, or ac. These are just examples, this list is not exhaustive, and there is no common index of identifiers here. Note that access technologies further along the path may also be relevant, e.g., a cellular backbone is not only the first hop, and there may be a DSL line behind the WiFi.
+Furthermore, endpoints may be able to influence both which domain they are in and which path elements in this domain to connect to, and they may be able to influence the properties of path elements within this domain.
+For example, a user might select between multiple potential path elements which are directly adjacent by selecting between multiple available WiFi Access Points. When connected to an Access Point, they may move closer to a it to enable their device to use a different access technology, potentially increasing the data rate available to the device.
+Another example is a user changing their data plan to reduce the Monetary Cost to transmit a given amount of data across a network.
+
+
+Access Technology:
+: The physical or link layer technology used on one or multiple path elements for transmitting a flow. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link, or as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
 
 Monetary Cost:
-: This is information related to billing, data caps, etc. It could be the allowed monthly data cap, the start and end of a billing period, the monetary cost per Megabyte sent or received, etc.
+: The price to be paid to transmit a specific flow across a set of path elements.
+
+Presence of a certain network function on the path:
+: Indicates that a certain path element performs a certain network function on a flow, e.g., whether the path element acts as a proxy, as a firewall, or performs Network Address Translation (NAT). This path element may be either in the same administrative domain as the endpoint or in a different administrative domain, i.e., the backbone.
 
 
 # Backbone Properties
 
-Backbone path properties relate to non-dynamic path properties that are not within the endpoint's domain.
-They are likely to stay constant within the lifetime of a connection, since Internet "backbone" routes change infrequently.
-These properties usually change on the timescale of seconds, minutes, or hours, when the route changes.
+Backbone path properties relate to path elements that are in a different administrative domain than an endpoint considering them, thus, in the backbone from the endpoint's point of view.
 
-Even if these properties change, endpoints can neither specify which backbone nodes to use, nor verify data was sent over these nodes.
-An endpoint can for example choose its access provider, but cannot choose the backbone path to a given destination since the access provider will make their own policy-based routing decision.
+Typically, backbone properties are less easily available to an endpoint than domain properties, due to the potential increased distance and the lack of pre-existing trust or contractual relationship.
 
-Presence of certain device on the path:
-: Could be the presence of a certain kind of middlebox, e.g., a proxy, a firewall, a NAT.
+Additionally, endpoints are less likely to be able to influence which path elements form their path in the backbone, as well as their properties.
 
-Presence of a packet forwarding node or specific Autonomous System on a path:
-: Indicates that traffic goes through a certain node or AS, which might be relevant for deciding the level of trust this path provides.
+Some path properties relate to the entire path, part of which often lies outside of an endpoint's administrative domain. Thus, such properties are listed as Backbone Properties.
+
+
+Administrative Entity:
+: The administrative entity, e.g., the AS, to which a path element or set of path elements belongs.
 
 Disjointness:
-: How disjoint a path is from another path.
+: For a set of two paths, the set of path elements which are shared.
 
 Path MTU:
 : The maximum size, in octets, of an IP packet that can be transmitted without fragmentation on a path segment or path.
 
 Transport Protocols available:
-: Whether a specific transport protocol can be used to establish a connection over this path. An endpoint may know this because it has cached whether it could successfully establish, e.g., a QUIC connection, or an MPTCP subflow.
+: Whether a specific transport protocol can be used to establish a connection over a path or path segment (ordered set of path elements). An endpoint may cache its knowledge about recent successfully established connections using specific protocols, e.g., a QUIC connection, or an MPTCP subflow, over a specific path.
 
 Protocol Features available:
-: Whether a specific feature within a protocol is known to work over this path, e.g., ECN, or TCP Fast Open.
+: Whether a specific protocol feature is available over this path, e.g., Explicit Congestion Notification (ECN), or TCP Fast Open.
 
 
 # Dynamic Properties
 
-Dynamic Path Properties are expected to change on the timescale of milliseconds.
-They usually relate to the state of the path, such as the current end-to-end latency.
-Some of these properties may depend only on the first hop or on the access network, some may depend on the entire path.
-Properties related to a single layer 2 domain are abstracted from the used physical and link layer technology, similar to {{RFC8175}}.
+Dynamic path properties relate to a path or path element with respect to the transmission of an individual packet or of a flow over a path element or path.
+Properties related to a path element which constitutes single layer 2 domain are abstracted from the used physical and link layer technology, similar to {{RFC8175}}.
 
 Typically, Dynamic Properties can only be approximated and sampled, and might be made available in an aggregated form, such as averages or minimums.
 Dynamic Path Properties can be measured by the endpoint itself or somethere in the network.
 See {{ANRW18-Metrics}} for a discussion of how to measure some dynamic path properties at the endpoint.
 
-
-These properties may be symmetric or asymmetric. For example, an asymmetric property may be different in the upstream direction and in the downstream direction from the point of view of a particular host.
+Some dynamic properties are defined in different directions for the same path element, e.g., for transmitting and receiving packets.
 
 
 Maximum Data Rate (Transmit/Receive):
@@ -131,17 +128,17 @@ Maximum Data Rate (Transmit/Receive):
 Current Data Rate (Transmit/Receive):
 : The data rate, in bits per second, at which a link is currently receiving or transmitting traffic.
 
-Round Trip Time:
-: Time from sending a packet to receiving a response from the remote endpoint.
+Latency:
+: The time delay between sending a packet on a path element and receiving the same packet on a different path element.
 
-Round Trip Time variation:
-: Disparity of Round Trip Time values either over time or among multiple concurrent connections. A high RTT variation often indicates congestion.
+Latency variation:
+: The variation of the Latency within a flow.
 
 Packet Loss:
-: Percentage of sent packets that are not received on the other end.
+: The percentage of packets within a flow which are sent by one path element, but not received by a different path element.
 
 Congestion:
-: Whether there is any indication of congestion on the path.
+: Whether a protocol feature such as ECN has provided information that there currently is congestion on a path.
 
 
 # Security Considerations

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -67,8 +67,14 @@ Path element:
 : A path element is a device (including the endpoints), or link used to connect two devices and transmit information on a specific layer.
 Path elements may exist on multiple layers (e.g., the endpoint corresponds to a path element on every layer), may be hidden on higher layers (e.g., a layer 2 switch in the local network), or a path element may be an aggregation of several path elements on a lower layer (e.g., the link connecting the endpoints on the transport layer being an aggregation of all network layer path elements).
 
+Path segment:
+: A path segment is an ordered set of path elements at the network layer that can be traversed by a packet.
+
 Path:
-: A path is defined as an ordered set of path elements at the network layer that can be traversed by a packet.
+: A path is defined as an ordered set of path elements at the network layer between two endpoints. A path can be traversed by a packet.
+
+Domain:
+: A path segment that is under the administrative control of a single entity.
 
 Flow:
 : Several packets traversing the same path elements can be combined into a flow (e.g., all packets sent within a UDP session which traverse the same path elements).
@@ -89,47 +95,47 @@ The notion of reliability depends on the property, it might be the confidence le
 
 # Domain Properties
 
-Domain path properties relate to path elements within the same Autonomous System (AS), thus, in the same administrative domain as an endpoint considering them.
+Domain path properties relate to path elements within the first hop or the first few hops, which are usually in the same administrative domain as an endpoint considering them.
 
-Due to the potential physical proximity and pre-existing trust or contractual relationships between endpoints and path elements within the same administrative domain, domain properties may be more easily available to the endpoint than the properties of path elements outside of its administrative domain.
+Due to the potential physical proximity and pre-existing trust or contractual relationships between endpoints and path elements within the same administrative domain, domain properties may be more accessible to the endpoint than other properties.
 
 Furthermore, endpoints may be able to influence both which domain they are in and which path elements in this domain to connect to, and they may be able to influence the properties of path elements within this domain.
-For example, a user might select between multiple potential path elements which are directly adjacent by selecting between multiple available WiFi Access Points. When connected to an Access Point, they may move closer to a it to enable their device to use a different access technology, potentially increasing the data rate available to the device.
+For example, a user might select between multiple potential adjacent path elements by selecting between multiple available WiFi Access Points. Or when connected to an Access Point, the user may move closer to enable their device to use a different access technology, potentially increasing the data rate available to the device.
 Another example is a user changing their data plan to reduce the Monetary Cost to transmit a given amount of data across a network.
 
 
 Access Technology:
-: The physical or link layer technology used on one or multiple path elements for transmitting a flow. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link, or as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
+: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements in the same administative domain. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link, or as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
 
 Monetary Cost:
 : The price to be paid to transmit a specific flow across a set of path elements.
 
-Presence of a certain network function on the path:
-: Indicates that a certain path element performs a certain network function on a flow, e.g., whether the path element acts as a proxy, as a firewall, or performs Network Address Translation (NAT). This path element may be either in the same administrative domain as the endpoint or in a different administrative domain, i.e., the backbone.
-
 
 # Backbone Properties
 
-Backbone path properties relate to path elements that are in a different administrative domain than an endpoint considering them, thus, in the backbone from the endpoint's point of view.
+Backbone path properties relate to path elements that not within the same domain as an endpoint considering them, thus, in the backbone from the endpoint's point of view.
 
-Typically, backbone properties are less easily available to an endpoint than domain properties, due to the potential increased distance and the lack of pre-existing trust or contractual relationship.
+Typically, backbone properties are less accessible to an endpoint than domain properties, due to the potential increased distance and the lack of pre-existing trust or contractual relationship.
 
 Additionally, endpoints are less likely to be able to influence which path elements form their path in the backbone, as well as their properties.
 
-Some path properties relate to the entire path, part of which often lies outside of an endpoint's administrative domain. Thus, such properties are listed as Backbone Properties.
+Some path properties relate to the entire path, part of which often lies outside of an endpoint's domain. Thus, such properties are listed as Backbone Properties.
 
+
+Presence of a certain network function on the path:
+: Indicates that a certain path element performs a certain network function on a flow, e.g., whether the path element acts as a proxy, as a firewall, or performs Network Address Translation (NAT). This path element may be either in the same domain as the endpoint or in a different domain, i.e., the backbone.
 
 Administrative Entity:
 : The administrative entity, e.g., the AS, to which a path element or set of path elements belongs.
 
 Disjointness:
-: For a set of two paths, the set of path elements which are shared.
+: For a set of two paths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). A multipath protocol might use disjointness of paths as a metric to reduce the number of single points of failure.
 
 Path MTU:
-: The maximum size, in octets, of an IP packet that can be transmitted without fragmentation on a path segment or path.
+: The maximum size, in octets, of an IP packet that can be transmitted without fragmentation on a path segment.
 
 Transport Protocols available:
-: Whether a specific transport protocol can be used to establish a connection over a path or path segment (ordered set of path elements). An endpoint may cache its knowledge about recent successfully established connections using specific protocols, e.g., a QUIC connection, or an MPTCP subflow, over a specific path.
+: Whether a specific transport protocol can be used to establish a connection over a path or path segment. An endpoint may cache its knowledge about recent successfully established connections using specific protocols, e.g., a QUIC connection, or an MPTCP subflow, over a specific path.
 
 Protocol Features available:
 : Whether a specific protocol feature is available over this path, e.g., Explicit Congestion Notification (ECN), or TCP Fast Open.
@@ -137,7 +143,7 @@ Protocol Features available:
 
 # Dynamic Properties
 
-Dynamic path properties relate to a path or path element with respect to the transmission of an individual packet or of a flow over a path element or path.
+Dynamic path properties relate to a path segment with respect to the transmission of an individual packet or of a flow over this path segment.
 Properties related to a path element which constitutes single layer 2 domain are abstracted from the used physical and link layer technology, similar to {{RFC8175}}.
 
 Typically, Dynamic Properties can only be approximated and sampled, and might be made available in an aggregated form, such as averages or minimums.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -94,7 +94,7 @@ The notion of reliability depends on the property, it might be the confidence le
 
 Domain path properties relate to path elements within the first hop or the first few hops, which are usually in the same administrative domain as an endpoint considering them.
 
-Due to the potential physical proximity and pre-existing trust or contractual relationships between endpoints and path elements within the same administrative domain, domain properties may be more accessible to the endpoint than other properties.
+Due to the potential physical proximity and pre-existing trust or contractual relationships between endpoints and path elements within the same domain, domain properties may be more accessible to the endpoint than other properties.
 
 Furthermore, endpoints may be able to influence both which domain they are in and which path elements in this domain to connect to, and they may be able to influence the properties of path elements within this domain.
 For example, a user might select between multiple potential adjacent path elements by selecting between multiple available WiFi Access Points. Or when connected to an Access Point, the user may move closer to enable their device to use a different access technology, potentially increasing the data rate available to the device.
@@ -102,10 +102,10 @@ Another example is a user changing their data plan to reduce the Monetary Cost t
 
 
 Access Technology:
-: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements in the same domain. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link, or as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
+: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements in the same domain. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link. It may also be given as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
 
 Monetary Cost:
-: The price to be paid to transmit a specific flow across a set of path elements.
+: The price to be paid to transmit a specific flow across a path segment.
 
 
 # Backbone Properties
@@ -123,7 +123,7 @@ Presence of a certain network function on the path:
 : Indicates that a certain path element performs a certain network function on a flow, e.g., whether the path element acts as a proxy, as a firewall, or performs Network Address Translation (NAT). This path element may be either in the same domain as the endpoint or in a different domain, i.e., the backbone.
 
 Administrative Entity:
-: The administrative entity, e.g., the AS, to which a path element or set of path elements belongs.
+: The administrative entity, e.g., the AS, to which a path element or path segment belongs.
 
 Disjointness:
 : For a set of two paths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). A multipath protocol might use disjointness of paths as a metric to reduce the number of single points of failure.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -73,9 +73,6 @@ Path segment:
 Path:
 : A path is defined as an ordered set of path elements at the network layer between two endpoints. A path can be traversed by a packet.
 
-Domain:
-: A path segment that is under the administrative control of a single entity.
-
 Flow:
 : Several packets traversing the same path elements can be combined into a flow (e.g., all packets sent within a UDP session which traverse the same path elements).
 As a special case, a flow can consist of just one packet.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -102,7 +102,7 @@ Another example is a user changing their data plan to reduce the Monetary Cost t
 
 
 Access Technology:
-: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements in the same administative domain. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link, or as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
+: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements in the same domain. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link, or as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
 
 Monetary Cost:
 : The price to be paid to transmit a specific flow across a set of path elements.
@@ -110,7 +110,7 @@ Monetary Cost:
 
 # Backbone Properties
 
-Backbone path properties relate to path elements that not within the same domain as an endpoint considering them, thus, in the backbone from the endpoint's point of view.
+Backbone path properties relate to path elements not within the same domain as an endpoint considering them, thus, in the backbone from the endpoint's point of view.
 
 Typically, backbone properties are less accessible to an endpoint than domain properties, due to the potential increased distance and the lack of pre-existing trust or contractual relationship.
 
@@ -141,7 +141,7 @@ Protocol Features available:
 # Dynamic Properties
 
 Dynamic path properties relate to a path segment with respect to the transmission of an individual packet or of a flow over this path segment.
-Properties related to a path element which constitutes single layer 2 domain are abstracted from the used physical and link layer technology, similar to {{RFC8175}}.
+Properties related to a path element which constitutes a single layer 2 domain are abstracted from the used physical and link layer technology, similar to {{RFC8175}}.
 
 Typically, Dynamic Properties can only be approximated and sampled, and might be made available in an aggregated form, such as averages or minimums.
 Dynamic Path Properties can be measured by the endpoint itself or somethere in the network.


### PR DESCRIPTION
I went over our property and category definitions and adjusted them to our new terminology.
In the process, PvDs went out of the draft, because they are related to how to get domain properties, not what domain properties exist. But maybe if we find we are missing PvD, we can add it again later.

Also, I realized that several properties relate to both path elements in the same domain and in the backbone. Overall, these categories are quite endpoint-centric, and maybe we want to rethink them at some point - not now though. ;)