### PR TITLE
Rephrase and restructure introduction

### DIFF
--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -29,6 +29,8 @@ informative:
 
     I-D.irtf-panrg-questions:
 
+    I-D.ietf-tcpm-converters:
+
     RFC8175:
 
     RFC5693:
@@ -57,41 +59,50 @@ This information is expressed as properties of paths between two hosts.
 
 # Introduction
 
-Because the current Internet provides an IP-based best-effort bit pipe, hosts have little information about paths to other hosts.
-A Path Aware Network exposes information about one or multiple paths through the network to hosts or the network infrastructure.
+In the current Internet architecture, hosts generally do not have information about forwarding paths through the network and about services associated with these paths.
+A path-aware network, as introduced in {{I-D.irtf-panrg-questions}}, exposes information about paths to hosts or to other entities.
+This document defines such information as path properties, addressing the first of the questions in path-aware networking {{I-D.irtf-panrg-questions}}.
 
-It is impossible to provide an exhaustive list of path properties, as with every new technology and protocol, novel properties might become relevant.
-In this document, we specify a set of path properties which might be useful in the following use cases: Traffic policies, network monitoring, and path selection.
+As terms related to paths have different meanings in different areas of networking, first, this document provides a common terminology to define paths, path elements, and path properties.
+Then, this document classifies path properties according to different criteria, e.g., how dynamic they are and to what path elements they apply.
+Finally, this document specifies a set of path properties
+which might be useful in the following use cases: Performance monitoring and enhancement, path selection, and traffic configuration.
+Note that with every new technology and protocol, novel properties might become relevant.
 
-- Traffic policies: Entities such as network operators or end users may want to define traffic policies leveraging path awareness.
-Such policies can allow or disallow sending traffic over specific networks or nodes, select an appropriate protocol depending on the capabilities of the on-path devices, or adjust protocol parameters to an existing path.
-An example of a traffic policy is a video streaming application choosing an (initial) video quality based on the achievable data rate, or the monetary cost of the link using a volume-based or flat-rate cost model.
-Another example is an enterprise network where all traffic has to go through a firewall, in which case the host needs to be aware of on-path firewalls.
+## Use Cases for Path Properties
 
-- Network monitoring: Network operators can use path properties (e.g., measured by on-path devices), to observe Quality of Service (QoS) characteristics of recent end-user traffic, and identify potential problems with their network early on, before the end-user complains.
+When a path-aware network exposes path properties to hosts or other entities,
+these entities may use this information to achieve different goals.
 
-- Path selection: In some cases, entities can choose to use a certain path (or subset of paths) from a set of paths to achieve a specific goal.
-As the possible benefits of a well chosen path varies based on the goal, as a baseline, a path selection algorithm should aim to not perform worse than the default case most of the time.
-Depending on the goal, an entity may prefer paths with different properties, e.g., retrieving a small webpage as quickly as possible requires low latency paths, or retrieving a large file in a peer-to-peer network requires paths with high achievable data rate.
-Additionally, there may be trade-offs between path properties (e.g., latency and data rate), and entities may influence these trade-offs with their choices.
+### Performance Monitoring and Enhancement
+
+Network operators can observe path properties (e.g., measured by on-path devices), to monitor Quality of Service (QoS) characteristics of recent end-user traffic on a path or subpath through their network. Such properties may help identify potential performance problems or trigger countermeasures to enhance performance.
+
+### Path Selection
+
+Entities can choose what traffic to send over which path or subset of paths.
+Entities may select their paths to fulfill a specific goal, e.g., related to security or performance.
+As an example of security-related path selection, an entity may allow or disallow sending traffic over paths involving specific networks or nodes to enforce traffic policies. In an enterprise network where all traffic has to go through a specific firewall, a path-aware host can implement this policy using path selection, in which case the host needs to be aware of paths involving that firewall.
+As an example of performance-related path selection,
+an entity may prefer paths with performance properties that best match its traffic, e.g., retrieving a small webpage as quickly as possible over a path with short One-Way Delays in both directions, or retrieving a large file over a path with high Link Capacities on all links.
+Note, there may be trade-offs between path properties (e.g., One-Way Delay and Link Capacity), and entities may influence these trade-offs with their choices.
+As a baseline, a path selection algorithm should aim to not perform worse than the default case most of the time.
+
+Path selection can be done both by hosts and by entities within the network:
 A network (e.g., an AS) can adjust its path selection for internal or external routing based on the path properties.
 In BGP, the Multi Exit Discriminator (MED) attribute decides which path to choose if other attributes are equal; in a path aware network, instead of using this single MED value, other properties such as maximum or available/expected data rate could additionally be used to improve load balancing.
 A host might be able to select between a set of paths, either if there are several paths to the same destination (e.g., if the host is a mobile device with two wireless interfaces, both providing a path), or if there are several destinations, and thus several paths, providing the same service (e.g., Application-Layer Traffic Optimization (ALTO) {{RFC5693}}, an application layer peer-to-peer protocol allowing hosts a better-than-random peer selection).
 Care needs to be taken when selecting paths based on path properties, as path properties that were previously measured may have become outdated and, thus, useless to predict the path properties of packets sent now.
 
-Such path properties may be relatively dynamic, e.g. current Round Trip Time, close to the origin, e.g. nature of the access technology on the first hop, or far from the origin, e.g. list of ASes traversed.
+### Traffic Configuration
 
-Usefulness over time is fundamentally different for dynamic and non-dynamic properties.
-The merit of a momentary measurement of a dynamic path property diminishes greatly as time goes on, e.g. the merit of an RTT measurement from a few seconds ago is quite small, while a non-dynamic path property might stay relevant, e.g. a NAT can be assumed to stay on a path during the lifetime of a connection, as the removal of the NAT would break the connection.
+When sending traffic over a specific path, entities can adjust this traffic based on the properties of the path.
+For example, an entity may select an appropriate protocol depending on the capabilities of the on-path devices,
+or adjust protocol parameters to an existing path.
+An example of traffic configuration is a video streaming application choosing an (initial) video quality based on the achievable data rate, or the monetary cost to send data across a network, eventually on a given path, using a volume-based or flat-rate cost model.
 
-Non-dynamic properties are further separated into (local) domain properties related to the first few hops of the connection, and backbone properties related to the remaining hops.
-Domain properties expose a high amount of information to hosts and strongly influence the connection behavior while there is little influence and information about backbone properties.
-
-Dynamic properties are not separated into domain and backbone properties, since most of these properties are defined for a complete path and it is difficult and seldom useful to define them on part of the path.
-There are exceptions such as dynamic wireless access properties, but these do not justify separation into different categories.
-
-This document addresses the first of the questions
-in Path-Aware Networking {{I-D.irtf-panrg-questions}}, which is a product of the PANRG in the IRTF.
+Conversely, the selection of a protocol may influence the devices that will be involved in a path.
+For example, a 0-RTT Transport Converter {{I-D.ietf-tcpm-converters}} will be involved in a path only when invoked by a host; such invocation will lead to the use of MPTCP or TCPinc capabilities while such use is not supported via the default forwarding path. Another example of traffic policies is a connection which may be composed of multiple streams; each stream with specific service requirements. A host may decide to invoke a given service function (e.g., transcoding) only for some streams while others are not processed by that service function.
 
 # Terminology
 
@@ -132,6 +143,24 @@ Measured property:
 
 Estimated property:
 : An approximate calculation or judgment of the value of a property. For example, an estimated property may describe the expected median one-way latency of packets sent on a path within the next second. An estimated property includes the reliability of the estimate. The notion of reliability depends on the property. For example, it may be the confidence level and interval for numerical properties or the likelihood that a property holds for non-numerical properties.
+
+# Path Property Classification
+
+Path properties may be relatively dynamic, e.g. median one-way delay of packets sent over a specific path within the last second.
+Path properties may also be non-dynamic, i.e., change less frequently, i.e., on a timescale of seconds or more.
+Usefulness over time is fundamentally different for dynamic and non-dynamic properties.
+The merit of a momentary measurement of a dynamic path property diminishes greatly as time goes on, e.g. the merit of an RTT measurement from a few seconds ago is quite small, while a non-dynamic path property might stay relevant for a longer period of time, e.g. a NAT typically stays on a specific path during the lifetime of a connection involving packets sent over this path.
+
+Moreover, path properties may relate to path elements close to the origin, e.g. nature of the access technology on the first hop, or extend to path elements far from the origin, e.g. list of ASes traversed.
+
+\[TODO: Remove split between domain and backbone properties? Or at least remove some of those claims? \]
+
+Non-dynamic properties are further separated into (local) domain properties related to the first few hops of the connection, and backbone properties related to the remaining hops.
+Domain properties expose a high amount of information to hosts and strongly influence the connection behavior while there is little influence and information about backbone properties.
+
+Dynamic properties are not separated into domain and backbone properties, since most of these properties are defined for a complete path and it is difficult and seldom useful to define them on part of the path.
+There are exceptions such as dynamic wireless access properties, but these do not justify separation into different categories.
+
 
 # Domain Properties
 
@@ -234,4 +263,4 @@ This document has no IANA actions.
 # Acknowledgments
 {:numbered="false"}
 
-Thanks to the Path-Aware Networking Research Group for the discussion and feedback. Thanks to Adrian Perrig and Matthias Rost for the feedback. Thanks to Paul Hoffman for the editorial changes.
+Thanks to the Path-Aware Networking Research Group for the discussion and feedback. Thanks to Mohamed Boudacair for the detailed review and text suggestions, and thanks to Adrian Perrig and Matthias Rost for the feedback. Thanks to Paul Hoffman for the editorial changes.


### PR DESCRIPTION
This addresses most comments in #14.

As a reference for architecture, we now refer to the questions draft, because that draft first what a path-aware network is.
Then, our introduction now explains the structure of the draft: Terminology, classification of properties, then some examples of properties.

For the examples of properties, we have use cases to motivate them. As these use cases became rather long and were not really suitable to be bullet points anymore, I split them into subsections.
Also, I reshuffled them, so "traffic policies" became "traffic configuration", because that's really what our examples are doing. I wanted to make the distinction between path selection and traffic configuration clear - path selection decides between different paths through the network, and then when a path has been selected, we can configure this path, which is traffic configuration. Therefore, the firewall example moved to "path selection".

Our old introduction contained a lot of text on classification of path properties. I kept this text, but moved it down after the terminology, because I think it fits better there.
Later, we'll have to think more about this classification, e.g., the domain properties issue, but I'd say this is out of scope for this PR now. ;)

What do you think?