### PR TITLE
Editorial and definition changes based on Med's review of -03

### DIFF
--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -180,7 +180,10 @@ Administrative Domain:
 : The administrative domain, e.g., the IGP area, AS, or Service provider network to which a path element belongs.
 
 Disjointness:
-: For a set of two paths or subpaths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). We typically say that a bidirectional path is symmetric if the path and reverse path have a Jaccard coefficient of one. A multipath protocol might use disjointness as a metric to reduce the number of single points of failure.
+: For a set of two paths or subpaths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). A multipath protocol might use disjointness as a metric to reduce the number of single points of failure.
+
+Symmetric Path:
+: Two paths are symmetric if a path and its reverse path consist of the same path elements, but in reverse order, i.e., the paths have a Jaccard coefficient of one.
 
 Path MTU:
 : The maximum size, in octets, of an IP packet that can be transmitted without fragmentation.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -56,7 +56,8 @@ informative:
 Path properties express information about paths across a network and the services provided via such paths.
 In a path-aware network, path properties may be fully or partially available to entities such as hosts.
 This document defines and categorizes path properties.
-Furthermore, the document specifies several path properties which might be useful to hosts or other entities.
+Furthermore, the document specifies several path properties which might be useful to hosts or other entities,
+e.g., for selecting between paths or for invoking some of the provided services.
 
 --- middle
 
@@ -73,20 +74,26 @@ Finally, the document lists several path properties that may be useful for the m
 # Terminology
 
 Node:
-: An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a machine or a service function. A node may also be the collection of multiple entities which, as a collection, processes packets, e.g., an entire Autonomous System (AS).
+: An entity which processes packets, e.g., sends, receives, forwards, or modifies them. A node may be physical or virtual, e.g., a physical device or a service function provided as a virtual element. A node may also be the collection of multiple entities which, as a collection, processes packets, e.g., an entire Autonomous System (AS).
 
 Host:
 : A node that generally executes application programs on behalf of user(s), employing network and/or Internet communication services in support of this function, as defined in {{?RFC1122}}.
 
 Link:
 : A medium or communication facility that connects two or more nodes with each other. A link enables a node to send packets to other nodes.
-Links can be physical, e.g., a WiFi network which connects an Access Point to stations, or virtual, e.g., a virtual switch which connects two virtual machines hosted on the same physical machine. A link is unidirectional and bidirectional communication can be modeled as two links between the same nodes in opposite directions.
+Links can be physical, e.g., a Wi-Fi network which connects an Access Point to stations, or virtual, e.g., a virtual switch which connects two virtual machines hosted on the same physical machine. A link is unidirectional. As such, bidirectional communication can be modeled as two links between the same nodes in opposite directions.
 
 Path element:
 : Either a node or a link.
 
 Path:
-: A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node. Paths are time-dependent, i.e., the sequence of path elements over which packets are sent from one node to another may change frequently. A path is defined between two nodes. For multicast or broadcast, a packet may be sent by one node and received by multiple nodes. In this case, the packet is sent over multiple paths at once, one path for each combination of sending and receiving node. Note that an entity may have only partial visibility of the path elements that comprise a path, and entities may treat path elements at different levels of abstraction.
+: A sequence of adjacent path elements over which a packet can be transmitted, starting and ending with a node. A path is unidirectional. Paths are time-dependent, i.e., the sequence of path elements over which packets are sent from one node to another may change. A path is defined between two nodes. For multicast or broadcast, a packet may be sent by one node and received by multiple nodes. In this case, the packet is sent over multiple paths at once, one path for each combination of sending and receiving node; these paths do not have to be disjoint. Note that an entity may have only partial visibility of the path elements that comprise a path and visibility may change over time. Different entities may have different visibility of a path and/or treat path elements at different levels of abstraction.
+
+Reverse Path:
+: The path that is used by a remote node in the context of bidirectional communication.
+
+Symmetric Path:
+: Denotes the case where the reverse path can be inferred from the path. For example, if the path is composed of path elements (PE1, PE2, PE3), if the path is symmetric, the reverse path is (PE3, PE2, PE1).
 
 Subpath:
 : Given a path, a subpath is a sequence of adjacent path elements of this path.
@@ -99,11 +106,11 @@ Property:
 A property is thus described by a tuple containing the path element(s), the flow or an empty set if no packets are relevant for the property, the name of the property (e.g., maximum data rate), and the value of the property (e.g., 1Gbps).
 
 Aggregated property:
-: A collection of multiple values of a property into a single value, according to a function. A property can be aggregated over multiple path elements (i.e., a path), e.g., the MTU of a path as the minimum MTU of all links on the path, over multiple packets (i.e., a flow), e.g., the median one-way latency of all packets between two nodes, or over both, e.g., the mean of the queueing delays of a flow on all nodes along a path.
+: A collection of multiple values of a property into a single value, according to a function. A property can be aggregated over multiple path elements (i.e., a subpath), e.g., the MTU of a path as the minimum MTU of all links on the path, over multiple packets (i.e., a flow), e.g., the median one-way latency of all packets between two nodes, or over both, e.g., the mean of the queueing delays of a flow on all nodes along a path.
 The aggregation function can be numerical, e.g., median, sum, minimum, it can be logical, e.g., "true if all are true", "true if at least 50\% of values are true", or an arbitrary function which maps multiple input values to an output value.
 
 Observed property:
-: A property that is observed for a specific path element or path, e.g., using measurements. For example, the one-way delay of a specific packet transmitted from one node to another node can be measured.
+: A property that is observed for a specific path element, subpath, or path, e.g., using measurements. For example, the one-way delay of a specific packet transmitted from one node to another node can be measured.
 
 Assessed property:
 : An approximate calculation or assessment of the value of a property. An assessed property includes the reliability of the calculation or assessment. The notion of reliability depends on the property.
@@ -149,40 +156,40 @@ For example, a 0-RTT Transport Converter {{I-D.ietf-tcpm-converters}} will be in
 
 # Examples of Path Properties
 
-This Section gives some examples of Path Properties which may be useful, e.g., for the use cases described in {{use-cases}}.
+This Section gives some examples of path properties which may be useful, e.g., for the use cases described in {{use-cases}}.
 
-Path properties may be relatively dynamic, e.g., the one-way delay of a packet sent over a specific path, or non-dynamic, e.g., the MTU of an ethernet link which only changes infrequently.
+Path properties may be relatively dynamic, e.g., the one-way delay of a packet sent over a specific path, or non-dynamic, e.g., the MTU of an Ethernet link which only changes infrequently.
 Usefulness over time differs depending on how dynamic a property is:
 The merit of a momentary measurement of a dynamic path property diminishes greatly as time goes on, e.g. the merit of an RTT measurement from a few seconds ago is quite small, while a non-dynamic path property might stay relevant for a longer period of time, e.g. a NAT typically stays on a specific path during the lifetime of a connection involving packets sent over this path.
 
-From the point of view of a host, path properties may relate to path elements close to the host, i.e., within the first few hops, or they may include path elements far from the host, e.g. list of ASes traversed.
+From the point of view of a host, path properties may relate to path elements close to the host, i.e., within the first few hops, or they may include path elements far from the host, e.g., list of ASes traversed.
 The visibility of path properties to a specific entity may depend on factors such as the physical or network distance or the existence of trust or contractual relationships between the entity and the path element(s).
 
 Furthermore, entities may or may not be able to influence the path elements on their path and their path properties.
-For example, a user might select between multiple potential adjacent links by selecting between multiple available WiFi Access Points. Or when connected to an Access Point, the user may move closer to enable their device to use a different access technology, potentially increasing the data rate available to the device.
-Another example is a user changing their data plan to reduce the Monetary Cost to transmit a given amount of data across a network.
+For example, a user might select between multiple potential adjacent links by selecting between multiple available Wi-Fi Access Points. Or when connected to an Access Point, the user may move closer to enable their device to use a different access technology, potentially increasing the data rate available to the device.
+Another example is a user changing their data plan to reduce the Monetary Cost to transmit or receive a given amount of data across a network.
 
 
 Access Technology:
-: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements. The Access Technology may be given in an abstract way, e.g., as a WiFi, Wired Ethernet, or Cellular link. It may also be given as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac WiFi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
+: The physical or link layer technology used for transmitting or receiving a flow on one or multiple path elements. The Access Technology may be given in an abstract way, e.g., as a Wi-Fi, Wired Ethernet, or Cellular link. It may also be given as a specific technology, e.g., as a 2G, 3G, 4G, or 5G cellular link, or an 802.11a, b, g, n, or ac Wi-Fi link. Other path elements relevant to the access technology may include on-path devices, such as elements of a cellular backbone network. Note that there is no common registry of possible values for this property.
 
 Monetary Cost:
-: The price to be paid to transmit a specific flow across a network to which one or multiple path elements belong.
+: The price to be paid to transmit or receive a specific flow across a network to which one or multiple path elements belong.
 
 Service function:
-: A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers.
+: A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers. Some stateful service functions, such as NAT, require the same instance to be involved in both directions, i.e., on the path and the reverse path.
 
 Administrative Domain:
-: The administrative domain, e.g., the ICP area, AS, or Service provider network to which a path element or subpath belongs.
+: The administrative domain, e.g., the IGP area, AS, or Service provider network to which a path element belongs.
 
 Disjointness:
-: For a set of two paths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). A multipath protocol might use disjointness of paths as a metric to reduce the number of single points of failure.
+: For a set of two paths or subpaths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). A multipath protocol might use disjointness as a metric to reduce the number of single points of failure.
 
 Path MTU:
-: The maximum size, in octets, of an IP packet that can be transmitted without fragmentation on a subpath.
+: The maximum size, in octets, of an IP packet that can be transmitted without fragmentation.
 
 Transport Protocols available:
-: Whether a specific transport protocol can be used to establish a connection over a path or subpath. A host may cache its knowledge about recent successfully established connections using specific protocols, e.g., a QUIC connection, or an MPTCP subflow.
+: Whether a specific transport protocol can be used to establish a connection over a path or subpath, e.g., whether the path is QUIC-capable or MPTCP-capable, based on cached knowledge.
 
 Protocol Features available:
 : Whether a specific protocol feature is available over a path or subpath, e.g., Explicit Congestion Notification (ECN), or TCP Fast Open.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -92,9 +92,6 @@ Path:
 Reverse Path:
 : The path that is used by a remote node in the context of bidirectional communication.
 
-Symmetric Path:
-: Denotes the case where the reverse path can be inferred from the path. For example, if the path is composed of path elements (PE1, PE2, PE3), if the path is symmetric, the reverse path is (PE3, PE2, PE1).
-
 Subpath:
 : Given a path, a subpath is a sequence of adjacent path elements of this path.
 
@@ -183,7 +180,7 @@ Administrative Domain:
 : The administrative domain, e.g., the IGP area, AS, or Service provider network to which a path element belongs.
 
 Disjointness:
-: For a set of two paths or subpaths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). A multipath protocol might use disjointness as a metric to reduce the number of single points of failure.
+: For a set of two paths or subpaths, the number of shared path elements can be a measure of intersection (e.g., Jaccard coefficient, which is the number of shared elements divided by the total number of elements). Conversely, the number of non-shared path elements can be a measure of disjointness (e.g., 1 - Jaccard coefficient). We typically say that a bidirectional path is symmetric if the path and reverse path have a Jaccard coefficient of one. A multipath protocol might use disjointness as a metric to reduce the number of single points of failure.
 
 Path MTU:
 : The maximum size, in octets, of an IP packet that can be transmitted without fragmentation.


### PR DESCRIPTION
This should cover everything discussed in #23 except the use cases section, which we tackle in another issue.
I added the definitions we promised to add while limiting our scope to definitions, i.e., not trying to go into how paths and path properties can be discovered. That's also why I cut some details for the "Transport Protocols available" property: Sure, a host can cache this because it's visible locally, but also based on probing as Med correctly pointed out, but let's try to avoid going into these different possibilities here.