### PR TITLE
Add transparency property

### DIFF
--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -181,7 +181,8 @@ Service function:
 : A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers.
 
 Transparency:
-: A service function that is transparent for a set of protocols is agnostic to and/or does not modify (meta-)information provided by these protocols. An IP router could be transparent for transport protocols such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
+: A node is transparent with respect to a protocol if it does not modify headers of this protocol and it processes packets independently of protocol-specific meta-information.
+An IP router could be transparent for transport protocols such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
 
 Administrative Domain:
 : The administrative domain, e.g., the ICP area, AS, or Service provider network to which a path element or subpath belongs.

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -180,6 +180,9 @@ Monetary Cost:
 Service function:
 : A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers.
 
+Transparency:
+: A service function that is transparent for a set of protocols is agnostic to and/or does not modify (meta-)information provided by these protocols. An IP router could be transparent for transport protocols such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
+
 Administrative Domain:
 : The administrative domain, e.g., the ICP area, AS, or Service provider network to which a path element or subpath belongs.
 


### PR DESCRIPTION
I defined transparency as a property of a service function.

I'm not sure if this restricts the usefulness of the transparency property.
Are there cases where transparency is relevant for nodes/links that are not service functions?

Do you have other suggestions how to define it?