### PR TITLE
Discuss secrecy/integrity protection in the Security Considerations

### DIFF
--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -229,6 +229,9 @@ Metrics such as loss patterns {{RFC3357}} and loss episodes {{RFC6534}} can be e
 If nodes are basing policy or path selection decisions on path properties, they need to rely on the accuracy of path properties that other devices communicate to them.
 In order to be able to trust such path properties, nodes may need to establish a trust relationship or be able to verify the authenticity, integrity, and correctness of path properties received from another node.
 
+Security related properties such as secrecy and integrity protection of payloads are difficult to characterize since they are defined with respect to a threat model which differs depending on the protocol and application.
+Such properties are orthogonal to the path terminology and path properties defined in this document, e.g., a VPN tunnel between two nodes offers secrecy and integrity protection for the flow on the (sub-)path between these nodes.
+
 
 # IANA Considerations
 

--- a/draft-enghardt-panrg-path-properties.md
+++ b/draft-enghardt-panrg-path-properties.md
@@ -229,8 +229,9 @@ Metrics such as loss patterns {{RFC3357}} and loss episodes {{RFC6534}} can be e
 If nodes are basing policy or path selection decisions on path properties, they need to rely on the accuracy of path properties that other devices communicate to them.
 In order to be able to trust such path properties, nodes may need to establish a trust relationship or be able to verify the authenticity, integrity, and correctness of path properties received from another node.
 
-Security related properties such as secrecy and integrity protection of payloads are difficult to characterize since they are defined with respect to a threat model which differs depending on the protocol and application.
-Such properties are orthogonal to the path terminology and path properties defined in this document, e.g., a VPN tunnel between two nodes offers secrecy and integrity protection for the flow on the (sub-)path between these nodes.
+Security related properties such as confidentiality and integrity protection of payloads are difficult to characterize since they are only meaningful with respect to a threat model which depends on the use case, application, environment, and other factors.
+Such properties are orthogonal to the path terminology and path properties defined in this document, as they are tied to the communicating entities and protocols used (e.g., client and server using HTTPS, or client and remote network node using VPN) and the path is typically oblivious to these properties.
+Intuitively, the path describes what function the network applies to packets, while confidentiality and integrity describe what function the communicating parties apply to packets.
 
 
 # IANA Considerations


### PR DESCRIPTION
Adds a paragraph to Security Considerations to discuss encryption and integrity protection and why we don't need explicit path properties for this.