### PR TITLE
Add table for different degrees of transparency

### DIFF
--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -185,19 +185,9 @@ Service function:
 : A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers. Some stateful service functions, such as NAT, require the same instance to be involved in both directions, i.e., on the path and the reverse path.
 
 Transparency:
-: A node perform an action transparently with respect to a protocol to a certain degree.
-The following table shows which action of a node (block packet, modify header, modify header+payload) is influenced by which inputs (while ignoring the not listed inputs).
-As a simplification, we consider a modifying action as a blocking action for the same input, i.e., a node that modifies a packet based on its header could also block the packet based on its header.
-
-|Action|Input|Degree|
-|Block|-|Header+Payload Transparent|
-|Block|Header|Payload Transparent Blocking|
-|Modify Header|Header|Payload Transparent Header Modification|
-|Block|Header+Payload|Blocking|
-|Modify Header|Header+Payload|Header Modification|
-|Modify Header+Payload|Header+Payload|Header+Payload Modification|
-
-An IP router could be transparent for transport protocols such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
+: We say that a node is transparent with respect to a protocol header, payload, or both for a specific action if the node performs this action independently of the given (meta-)information.
+Actions can for example be blocking packets or reading and modifying (other protocol) headers or payloads.
+An IP router could be transparent for transport protocol headers such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
 
 Administrative Domain:
 : The administrative domain, e.g., the IGP area, AS, or Service provider network to which a path element belongs.

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -185,7 +185,18 @@ Service function:
 : A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers. Some stateful service functions, such as NAT, require the same instance to be involved in both directions, i.e., on the path and the reverse path.
 
 Transparency:
-: A node is transparent with respect to a protocol if it does not modify headers of this protocol and it processes packets independently of protocol-specific meta-information.
+: A node perform an action transparently with respect to a protocol to a certain degree.
+The following table shows which action of a node (block packet, modify header, modify header+payload) is influenced by which inputs (while ignoring the not listed inputs).
+As a simplification, we consider a modifying action as a blocking action for the same input, i.e., a node that modifies a packet based on its header could also block the packet based on its header.
+
+|Action|Input|Degree|
+|Block|-|Header+Payload Transparent|
+|Block|Header|Payload Transparent Blocking|
+|Modify Header|Header|Payload Transparent Header Modification|
+|Block|Header+Payload|Blocking|
+|Modify Header|Header+Payload|Header Modification|
+|Modify Header+Payload|Header+Payload|Header+Payload Modification|
+
 An IP router could be transparent for transport protocols such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
 
 Administrative Domain:

--- a/draft-irtf-panrg-path-properties.md
+++ b/draft-irtf-panrg-path-properties.md
@@ -185,7 +185,7 @@ Service function:
 : A service function that a path element applies to a flow, see {{RFC7665}}. Examples of abstract service functions include firewalls, Network Address Translation (NAT), and TCP optimizers. Some stateful service functions, such as NAT, require the same instance to be involved in both directions, i.e., on the path and the reverse path.
 
 Transparency:
-: We say that a node is transparent with respect to a protocol header, payload, or both for a specific action if the node performs this action independently of the given (meta-)information.
+: A node is transparent with respect to a protocol header, payload, or both for a specific action if the node performs this action independently of the given (meta-)information.
 Actions can for example be blocking packets or reading and modifying (other protocol) headers or payloads.
 An IP router could be transparent for transport protocol headers such as TCP and UDP, in contrast to a NAT that actively modifies TCP and UDP header information.
 


### PR DESCRIPTION
I added a table for different node behaviors (block, modify, ...) based on different inputs.
I'm not sure if this table is useful/consistent since different actions might have different inputs which cannot be represented in a reasonably small table.

An alternative approach instead of the table would be to add some text which describes the main takeaways from the table, i.e., node might block but not modify, node might modify headers but be transparent to payloads, ...